### PR TITLE
Add support for slurm-operator namespace

### DIFF
--- a/kubernetes/cray-tapms-operator/templates/rbac.yaml
+++ b/kubernetes/cray-tapms-operator/templates/rbac.yaml
@@ -96,6 +96,7 @@ rules:
   - hnc.x-k8s.io
   resources:
   - subnamespaceanchors
+  - hierarchyconfigurations
   verbs:
   - create
   - delete

--- a/kubernetes/cray-tapms-operator/templates/webhook.yaml
+++ b/kubernetes/cray-tapms-operator/templates/webhook.yaml
@@ -111,7 +111,7 @@ spec:
     - server auth
     - client auth
   dnsNames:
-    - "tapms-webhook-service.tenants.svc"
+    - "tapms-webhook-service.tapms-operator.svc"
   issuerRef:
     name: cert-manager-issuer-common
     kind: Issuer

--- a/main.go
+++ b/main.go
@@ -117,10 +117,21 @@ func main() {
 		setupLog.Error(err, "unable to create controller", "controller", "Tenants")
 		os.Exit(1)
 	}
+
+	if err = (&controllers.TenantReconciler{
+		Client: mgr.GetClient(),
+		Log:    ctrl.Log.WithName("controllers").WithName("Tenants"),
+		Scheme: mgr.GetScheme(),
+	}).BuildRootTreeStructure(mgr); err != nil {
+		setupLog.Error(err, "unable build initial tree structure")
+		os.Exit(1)
+	}
+
 	if err = (&tapmshpecomv1alpha1.Tenant{}).SetupWebhookWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "Tenant")
 		os.Exit(1)
 	}
+
 	//+kubebuilder:scaffold:builder
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {


### PR DESCRIPTION
## Summary and Scope

Refactor namespaces controlled by hnc controller, create specific namespaces for tapms and slurm.

## Issues and Related PRs

* Resolves [CASMINST-4841](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4841)
* Resolves [CASMINST-4843](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4843)

## Testing

```
multi-tenancy
├── slurm-operator
├── tapms-operator
└── tenants
    ├── [s] vcluster-coke
    │   └── [s] vcluster-coke-user
    └── [s] vcluster-pepsi
        └── [s] vcluster-pepsi-user

[s] indicates subnamespaces
```

```
ncn-m001-48d9c509:/home/bklein # kubectl get secrets -n slurm-operator
NAME                  TYPE                                  DATA   AGE
default-token-vt5br   kubernetes.io/service-account-token   3      4m2s
wlm-s3-credentials    Opaque                                7      2m23s
```


### Tested on:

  * Virtual Shasta

### Test description:

Installed/uninstalled the following charts in concert:

```
   - name: cray-drydock
     version: 2.14.5
     namespace: loftsman
   - name: cray-vault
     version: 1.3.6
     namespace: vault
   - name: cray-psp
     version: 0.4.3
     namespace: services
   - name: cray-certmanager-issuers
     version: 0.6.5
     namespace: cert-manager
   - name: cray-hnc-manager
     version: 0.0.1
     namespace: hnc-system
   - name: cray-tapms-operator
     version: 0.0.1
     namespace: tapms-operator
   - name: cray-sample-subtenant-operator
     version: 0.0.1
     namespace: tenants
```

## Risks and Mitigations

Low

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable