### PR TITLE
CASMPET-7030: Update CRD chart to use different kubectl container

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -16,11 +16,14 @@ pipeline {
 
         OPERATOR_DESCRIPTION = "HPE Tenant and Partition Management Service Operator"
         OPERATOR_CHART_NAME = "cray-tapms-operator"
+        OPERATOR_CHART_PATTERN = "cray-tapms-operator-*.tgz"
         OPERATOR_CHART_VERSION = getChartVersion(name: env.OPERATOR_CHART_NAME, isStable: env.IS_STABLE)
+
         DOCKER_ARGS = getDockerBuildArgs(name: env.OPERATOR_CHART_NAME, description: env.OPERATOR_DESCRIPTION)
 
         CRD_DESCRIPTION = "HPE Tenant and Partition Management Service CRD Chart"
         CRD_CHART_NAME = "cray-tapms-crd"
+        CRD_CHART_PATTERN = "cray-tapms-crd-*.tgz"
         CRD_CHART_VERSION = getChartVersion(name: env.CRD_CHART_NAME, isStable: env.IS_STABLE)
     }
 
@@ -46,8 +49,8 @@ pipeline {
             steps {
                 script {
                     publishCsmDockerImage(image: env.OPERATOR_CHART_NAME, tag: env.DOCKER_VERSION, isStable: env.IS_STABLE)
-                    publishCsmHelmCharts(component: env.OPERATOR_CHART_NAME, chartsPath: "${WORKSPACE}/kubernetes/.packaged", isStable: env.IS_STABLE)
-                    publishCsmHelmCharts(component: env.CRD_CHART_NAME, chartsPath: "${WORKSPACE}/kubernetes/.packaged", isStable: env.IS_STABLE)
+                    publishCsmHelmCharts(component: env.OPERATOR_CHART_NAME, chartsPath: "${WORKSPACE}/kubernetes/.packaged", chartsPattern: env.OPERATOR_CHART_PATTERN, isStable: env.IS_STABLE)
+                    publishCsmHelmCharts(component: env.CRD_CHART_NAME, chartsPath: "${WORKSPACE}/kubernetes/.packaged", chartsPattern: env.CRD_CHART_PATTERN, isStable: env.IS_STABLE)
                 }
             }
         }

--- a/kubernetes/cray-tapms-crd/Chart.yaml
+++ b/kubernetes/cray-tapms-crd/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-tapms-crd
-version: 1.9.1
+version: 1.9.2
 description: Tenant and Partition Management Custom Resource Definition Chart
 keywords:
   - cray-tapms

--- a/kubernetes/cray-tapms-crd/values.yaml
+++ b/kubernetes/cray-tapms-crd/values.yaml
@@ -23,6 +23,6 @@
 #
 util:
   image:
-    repository: artifactory.algol60.net/csm-docker/stable/docker.io/demisto/boto3py3
-    tag: kubectl_v1_21_12_1.0.0.49259
+    repository: artifactory.algol60.net/csm-docker/stable/docker-kubectl
+    tag: 1.32.2
     pullPolicy: IfNotPresent


### PR DESCRIPTION
## Summary and Scope

This uses a better kubectl image to limit extra kubectl images on the systems

## Issues and Related PRs

* Resolves [CASMPET-7030](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7030)

## Testing

### Tested on:

  * beau

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

